### PR TITLE
Fixing Jenkins failure for py3.5

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,7 +33,7 @@ for (python_ver in matrix_python) {
     // (Required) Execute a series of commands to set up the build
     bc.build_cmds = [
         "pip install pytest",
-        "pyip install .",
+        "pip install .",
     ]
 
     // (Optional) Execute a series of test commands

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,7 +33,7 @@ for (python_ver in matrix_python) {
     // (Required) Execute a series of commands to set up the build
     bc.build_cmds = [
         "pip install pytest",
-        "python setup.py install",
+        "pyip install .",
     ]
 
     // (Optional) Execute a series of test commands


### PR DESCRIPTION
A failure of jenkins for python 3.5 was found because too new of an astropy version was being installed (astropy 4.0) which no longer accepts python 3.5. This PR attempts to fix that problem