### PR TITLE
Add catch for stars below faint magnitude

### DIFF
--- a/fgscountrate/fgs_countrate_core.py
+++ b/fgscountrate/fgs_countrate_core.py
@@ -165,7 +165,7 @@ class FGSCountrate:
 
         # Convert to JHK magnitudes
         self.j_mag, self.j_mag_err, self.h_mag, self.h_mag_err, self.k_mag, self.k_mag_err = \
-            self.calc_jhk_mag(self.gsc_series)
+            self.calc_jhk_mag()
 
         # Compute FGS countrate and magnitude
         self.fgs_countrate, self.fgs_countrate_err, \
@@ -173,17 +173,18 @@ class FGSCountrate:
 
         return self.fgs_countrate, self.fgs_countrate_err, self.fgs_magnitude, self.fgs_magnitude_err
 
-    def calc_jhk_mag(self, data):
+    def calc_jhk_mag(self, data=None):
         """
         Calculate the J, H, and K magnitudes of the input data
 
         Parameters
         ----------
-        data : pandas series
+        data : pandas series, optional
             A pd series containing at least the following bands:
             GSC2: JpgMag, FpgMag, NpgMag
             2MASS: tmassJmag, tmassHmag, tmassKsMag
             SDSS: SDSSgMag, SDSSiMag, SDSSzMag
+            If not passed, will use self.gsc_series
 
         Returns
         -------
@@ -194,7 +195,10 @@ class FGSCountrate:
         """
 
         # Pull all the magnitudes from the series
-        self._all_queried_mag_series = data.loc[GSC_BAND_NAMES]
+        if data is not None:
+            self.gsc_series = data
+
+        self._all_queried_mag_series = self.gsc_series.loc[GSC_BAND_NAMES]
 
         # Pull magnitude errors for each band, and replace missing errors with 2.5% of the magnitude value
         mag_err_list = [self.gsc_series[ind + 'Err'] if self.gsc_series[ind + 'Err'] != -999

--- a/fgscountrate/fgs_countrate_core.py
+++ b/fgscountrate/fgs_countrate_core.py
@@ -224,9 +224,18 @@ class FGSCountrate:
             # Pull the first entry in the OrderedDict that matches what values are present.
             for key, value in switcher.items():
                 key_list = key.split(', ')
+
                 if set(key_list).issubset(self._present_queried_mags):
+
+                    # Check for faint star limits
+                    mags = self._all_queried_mag_series[key_list].values
+                    if utils.check_band_below_faint_limits(key_list, mags):
+                        continue
+
+                    # Set the conversion method
                     setattr(self, '{}_convert_method'.format(i[5].lower()), value)
                     break
+
             if getattr(self, '{}_convert_method'.format(i[5].lower())) is None:
                 raise ValueError('There is not enough information on this guide star to get its {} magnitude'.format(i))
 
@@ -303,7 +312,7 @@ class FGSCountrate:
 
         # Add magnitudes
         df = pd.concat([df, band_series], axis=1, sort=True)
-        df = df.rename(columns={0: 'Mag'})
+        df.columns = ['Wavelength', 'Mag']
         
         # Sort to order of increasing wavelength
         df = df.sort_values(by=['Wavelength'])

--- a/fgscountrate/utils.py
+++ b/fgscountrate/utils.py
@@ -132,3 +132,39 @@ def query_gsc(gs_id=None, ra=None, dec=None, cone_radius=None, minra=None, maxra
         raise NameError("No guide stars match these requirements in catalog {}".format(catalog))
 
     return data_frame
+
+
+def check_band_below_faint_limits(bands, mags):
+    """
+    Check if a star's magnitude for a certain band is below the the
+    faint limit for that band.
+
+    Parameters
+    ----------
+    bands : str or list
+        Band(s) to check (e.g. ['SDSSgMag', 'SDSSiMag'].
+    mags : str or list
+        Magnitude(s) of the band(s) corresponding to the band(s) in the
+        band svariable
+
+    Returns
+    -------
+    bool : True if the band if below the faint limit. False if it is not
+    """
+
+    if isinstance(bands, str):
+        bands = [bands]
+    if isinstance(mags, str):
+        mags = [mags]
+
+    for band, mag in zip(bands, mags):
+        if 'SDSSgMag' in band and mag >= 24:
+            return True
+        elif 'SDSSrMag' in band and mag >= 24:
+            return True
+        elif 'SDSSiMag' in band and mag >= 23:
+            return True
+        elif 'SDSSzMag' in band and mag >= 22:
+            return True
+
+    return False

--- a/fgscountrate/utils.py
+++ b/fgscountrate/utils.py
@@ -145,7 +145,7 @@ def check_band_below_faint_limits(bands, mags):
         Band(s) to check (e.g. ['SDSSgMag', 'SDSSiMag'].
     mags : str or list
         Magnitude(s) of the band(s) corresponding to the band(s) in the
-        band svariable
+        bands variable
 
     Returns
     -------


### PR DESCRIPTION
The equations used in this tool are only applicable for stars that are beyond the "faint limit" for their band, so we have added a check for these magnitudes. If a star has a band below it's faint limit, the code will check if it can use another set of bands to do the calculation (and check if those are below the faint limit). If it can, the code will use those bands instead. If it can't, the code will raise the same error that is does for stars with not enough bands: "ValueError: There is not enough information on this guide star..."

I also added a few simple fixes to streamline parts of the code, but nothing that should change any functionality.

For future reference, we hope to add a new method for calculating the j, h, and k magnitudes from these faint stars (e.g. by making a stellar type assumption) but this will take more time.