### PR TITLE
Algorithm updates to better match GSSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ JWST FGS countrate estimation
 [![Build Status](https://ssbjenkins.stsci.edu/job/STScI/job/jwst-fgs-countrate/job/master/badge/icon)](https://ssbjenkins.stsci.edu/job/STScI/job/jwst-fgs-countrate/job/master/)
 
 
-jwst-fgs-countrate converts guide star information from different catalogs into the expected countrate for the JWST Fine Guidance Sensor (FGS). This is done by querying the Guide Star Catalog (containing GSC2, 2MASS, SDSS, and eventually GAIA data) based on the input of the guide star’s HST ID number and using information from that catalog to calculate a countrate.
+jwst-fgs-countrate converts guide star information from different catalogs into the expected countrate for the JWST Fine Guidance Sensor (FGS). This is done by querying the Guide Star Catalog (containing 2MASS, SDSS, and GSC2) based on the input of the guide star’s HST ID number and using information from that catalog to calculate a count rate and FGS magnitude. The code is aimed to match the version of the Guide Star Selection System used during JWST commisisoning. 
 
 Collaborators include Shannon Osborne ([@shanosborne](https://github.com/shanosborne)), Sherie Holfeltz ([@stholfeltz](https://github.com/stholfeltz)), and Pierre Chayer.
 

--- a/fgscountrate/__init__.py
+++ b/fgscountrate/__init__.py
@@ -25,7 +25,7 @@ except FileNotFoundError:
     print('Could not determine fgscountrate version')
     __version__ = '0.0.0'
 
-__minimum_python_version__ = "3.5"
+__minimum_python_version__ = "3.6"
 
 
 class UnsupportedPythonError(Exception):

--- a/fgscountrate/constants.py
+++ b/fgscountrate/constants.py
@@ -1,0 +1,74 @@
+"""Constants used in fgs_countrate_core.py and utils.py"""
+
+# Universal constant
+PLANCK = 6.625e-27
+
+# Guide star catalog band information
+GSC_BAND_NAMES = ['tmassJMag', 'tmassHMag', 'tmassKsMag',
+                  'SDSSuMag', 'SDSSgMag', 'SDSSrMag', 'SDSSiMag',
+                  'SDSSzMag', 'JpgMag', 'FpgMag', 'NpgMag']
+GSC_BAND_WAVELENGTH = [1.25, 1.65, 2.17,
+                       0.3551, 0.4680, 0.6166, 0.7480,
+                       0.8932, 0.4660, 0.6450, 0.8500]
+
+# Factor to use when calculating a band's missing uncertainty
+BAND_ERR = 0.025
+
+# FGS-Guider + OTE throughput
+THROUGHPUT_G1 = {
+    0.3551: 0.0,
+    0.4660: 0.042,
+    0.4680: 0.044,
+    0.6166: 0.389,
+    0.6450: 0.487,
+    0.7480: 0.586,
+    0.8500: 0.655,
+    0.8932: 0.707,
+    1.25: 0.688,
+    1.65: 0.633,
+    2.17: 0.723,
+    3.0: 0.744,
+    4.0: 0.690,
+    5.0: 0.548,
+    5.5: 0.041,
+}
+THROUGHPUT_G2 = {
+    0.3551: 0.0,
+    0.4660: 0.020,
+    0.4680: 0.021,
+    0.6166: 0.289,
+    0.6450: 0.390,
+    0.7480: 0.628,
+    0.8500: 0.669,
+    0.8932: 0.647,
+    1.25: 0.761,
+    1.65: 0.603,
+    2.17: 0.635,
+    3.0: 0.735,
+    4.0: 0.738,
+    5.0: 0.687,
+    5.5: 0.040,
+}
+
+# Countrate conversion factors
+CR_CONVERSION_G1 = 1.74
+CR_CONVERSION_G2 = 1.57
+
+# Magnitude conversion constant
+MAG_CONVERSION_G1 = 28.29
+MAG_CONVERSION_G2 = 28.20
+
+# Conversion constants from Jmag to ABmag
+ABMAG_CONSTANTS = {
+    'tmassJMag': 0.90,
+    'tmassHMag': 1.37,
+    'tmassKsMag': 1.85,
+    'SDSSuMag': 0.0,
+    'SDSSgMag': 0.0,
+    'SDSSrMag': 0.0,
+    'SDSSiMag': 0.0,
+    'SDSSzMag': 0.0,
+    'JpgMag': -0.055,
+    'FpgMag': 0.24,
+    'NpgMag': 0.48,
+}

--- a/fgscountrate/conversions.py
+++ b/fgscountrate/conversions.py
@@ -67,6 +67,72 @@ def convert_tmass_to_jhk(data, output_mag):
         raise ValueError("output_mag must be set to either J, H, or K")
 
 
+def convert_sdssrz_to_jhk(data, output_mag):
+    """
+    Convert from SDSS_r mag and SDSS_z mag to J,H,K mag
+
+    Parameters
+    ----------
+    data : Pandas Series or tuple
+        Either a pandas Series as the output from a query
+        of the Guide Star Catalog or a tuple containing the
+        values (SDSS_r, SDSS_r_err, SDSS_z, SDSS_z_err)
+    output_mag : str
+        The magnitude you want to convert to. Options
+        are 'J', 'H', or 'K'.
+
+    Returns
+    -------
+    JHK_mag : float
+        The magnitude (J, H, or K based on the output_mag keyword)
+    JHK_err : float
+        The uncertainty of the magnitude
+    """
+    if isinstance(data, pd.Series):
+        r_mag = data['SDSSrMag']
+        r_err = data['SDSSrMagErr']
+        z_mag = data['SDSSzMag']
+        z_err = data['SDSSzMagErr']
+    elif isinstance(data, tuple):
+        r_mag = data[0]
+        r_err = data[1]
+        z_mag = data[2]
+        z_err = data[3]
+    else:
+        raise TypeError(f"{type(data)} is not a valid type for data. Must be a tuple (mag, mag_err) "
+                        f"or a pd.Series output from the Guide Star Catalog")
+
+    if output_mag.upper() == 'J':
+        def calc_j(r, z):
+            return r - 0.71 - 1.93 * (r - z) + 0.66 * (r - z) ** 2 - 0.24 * (r - z) ** 3 + 0.30 * (r - z) ** 4
+        j = calc_j(r_mag, z_mag)
+        err_j_r = calc_j(r_mag + r_err, z_mag) - j
+        err_j_z = calc_j(r_mag, z_mag + z_err) - j
+        sigma_j_eqn = 0.1
+        j_err = np.sqrt(err_j_r**2 + err_j_z**2 + sigma_j_eqn**2)
+        return j, j_err
+    elif output_mag.upper() == 'H':
+        def calc_h(r, z):
+            return r - 0.85 - 3.26 * (r - z) + 1.81 * (r - z) ** 2 - 0.63 * (r - z) ** 3 + 0.08 * (r - z) ** 4
+        h = calc_h(r_mag, z_mag)
+        err_h_r = calc_h(r_mag + r_err, z_mag) - h
+        err_h_z = calc_h(r_mag, z_mag + z_err) - h
+        sigma_h_eqn = 0.128
+        h_err = np.sqrt(err_h_r**2 + err_h_z**2 + sigma_h_eqn**2)
+        return h, h_err
+    elif output_mag.upper() == 'K':
+        def calc_k(r, z):
+            return r - 0.91 - 3.38 * (r - z) + 1.77 * (r - z) ** 2 - 0.60 * (r - z) ** 3 + 0.07 * (r - z) ** 4
+        k = calc_k(r_mag, z_mag)
+        err_k_r = calc_k(r_mag + r_err, z_mag) - k
+        err_k_z = calc_k(r_mag, z_mag + z_err) - k
+        sigma_k_eqn = 0.179
+        k_err = np.sqrt(err_k_r**2 + err_k_z**2 + sigma_k_eqn**2)
+        return k, k_err
+    else:
+        raise ValueError("output_mag must be set to either J, H, or K")
+
+
 def convert_sdssgz_to_jhk(data, output_mag):
     """
     Convert from SDSS_g mag and SDSS_z mag to J,H,K mag

--- a/fgscountrate/conversions.py
+++ b/fgscountrate/conversions.py
@@ -54,8 +54,8 @@ def convert_tmass_to_jhk(data, output_mag):
             k_mag = data[0]
             k_err = data[1]
     else:
-        raise TypeError("{} is not a valid type for data. Must be a tuple (mag, mag_err) or a pd.Series output "
-                        "from the Guide Star Catalog".format(type(data)))
+        raise TypeError(f"{type(data)} is not a valid type for data. Must be a tuple (mag, mag_err) "
+                        f"or a pd.Series output from the Guide Star Catalog")
 
     if output_mag.upper() == 'J':
         return j_mag, j_err
@@ -99,8 +99,8 @@ def convert_sdssgz_to_jhk(data, output_mag):
         z_mag = data[2]
         z_err = data[3]
     else:
-        raise TypeError("{} is not a valid type for data. Must be a tuple (g,g_err,z,z_err) or a pd.Series output "
-                        "from the Guide Star Catalog".format(type(data)))
+        raise TypeError(f"{type(data)} is not a valid type for data. Must be a tuple (mag, mag_err) "
+                        f"or a pd.Series output from the Guide Star Catalog")
 
     if output_mag.upper() == 'J':
         def calc_j(g, z):
@@ -165,8 +165,8 @@ def convert_sdssgi_to_jhk(data, output_mag):
         i_mag = data[2]
         i_err = data[3]
     else:
-        raise TypeError("{} is not a valid type for data. Must be a tuple (g,g_err,i,i_err) or a pd.Series output "
-                        "from the Guide Star Catalog".format(type(data)))
+        raise TypeError(f"{type(data)} is not a valid type for data. Must be a tuple (mag, mag_err) "
+                        f"or a pd.Series output from the Guide Star Catalog")
 
     if output_mag.upper() == 'J':
         def calc_j(g, i):
@@ -231,8 +231,8 @@ def convert_sdssiz_to_jhk(data, output_mag):
         z_mag = data[2]
         z_err = data[3]
     else:
-        raise TypeError("{} is not a valid type for data. Must be a tuple (i,i_err,z,z_err) or a pd.Series output "
-                        "from the Guide Star Catalog".format(type(data)))
+        raise TypeError(f"{type(data)} is not a valid type for data. Must be a tuple (mag, mag_err) "
+                        f"or a pd.Series output from the Guide Star Catalog")
 
     if output_mag.upper() == 'J':
         def calc_j(i, z):
@@ -297,8 +297,8 @@ def convert_gsc2bjin_to_jhk(data, output_mag):
         i_n_mag = data[2]
         i_n_err = data[3]
     else:
-        raise TypeError("{} is not a valid type for data. Must be a tuple (b_j,b_j_err,i_n,i_n_err) "
-                        "or a pd.Series output from the Guide Star Catalog".format(type(data)))
+        raise TypeError(f"{type(data)} is not a valid type for data. Must be a tuple (mag, mag_err) "
+                        f"or a pd.Series output from the Guide Star Catalog")
 
     if output_mag.upper() == 'J':
         def calc_j(b_j, i_n): return b_j - 1.30 * (b_j - i_n) - 0.15
@@ -360,8 +360,8 @@ def convert_gsc2rfin_to_jhk(data, output_mag):
         i_n_mag = data[2]
         i_n_err = data[3]
     else:
-        raise TypeError("{} is not a valid type for data. Must be a tuple (r_f,r_f_err,i_n,i_n_err) or a "
-                        "pd.Series output from the Guide Star Catalog".format(type(data)))
+        raise TypeError(f"{type(data)} is not a valid type for data. Must be a tuple (mag, mag_err) "
+                        f"or a pd.Series output from the Guide Star Catalog")
 
     if output_mag.upper() == 'J':
         def calc_j(r_f, i_n): return r_f + 0.01 * (r_f - i_n) ** 2 - 1.56 * (r_f - i_n) - 0.44
@@ -423,8 +423,8 @@ def convert_gsc2bjrf_to_jhk(data, output_mag):
         r_f_mag = data[2]
         r_f_err = data[3]
     else:
-        raise TypeError("{} is not a valid type for data. Must be a tuple (b_j,b_j_err,r_f,r_f_err) or a "
-                        "pd.Series output from the Guide Star Catalog".format(type(data)))
+        raise TypeError(f"{type(data)} is not a valid type for data. Must be a tuple (mag, mag_err) "
+                        f"or a pd.Series output from the Guide Star Catalog")
 
     if output_mag.upper() == 'J':
         def calc_j(b_j, r_f): return b_j - 0.39 * (b_j - r_f) ** 2 - 0.96 * (b_j - r_f) - 0.55

--- a/fgscountrate/conversions.py
+++ b/fgscountrate/conversions.py
@@ -452,3 +452,12 @@ def convert_gsc2bjrf_to_jhk(data, output_mag):
         return k, k_err
     else:
         raise ValueError("output_mag must be set to either J, H, or K")
+
+
+def cannot_calculate(**kwargs):
+    """
+    Helper function to be called when there is not enough available data
+    to preform a J, H, or K calculation. In this case, we'll return -999
+    for the band and error.
+    """
+    return -999, -999

--- a/fgscountrate/conversions.py
+++ b/fgscountrate/conversions.py
@@ -188,7 +188,7 @@ def convert_sdssgz_to_jhk(data, output_mag):
         return h, h_err
     elif output_mag.upper() == 'K':
         def calc_k(g, z):
-            return g - 0.87 - 1.70 * (g - z) - 0.01 * (g - z) ** 2 + 0.07 * (g - z) ** 3 - 0.001 * (g - z) ** 4
+            return g - 0.87 - 1.70 * (g - z) - 0.01 * (g - z) ** 2 + 0.07 * (g - z) ** 3 - 0.01 * (g - z) ** 4
         k = calc_k(g_mag, z_mag)
         err_k_g = calc_k(g_mag + g_err, z_mag) - k
         err_k_z = calc_k(g_mag, z_mag + z_err) - k

--- a/fgscountrate/fgs_countrate_core.py
+++ b/fgscountrate/fgs_countrate_core.py
@@ -171,6 +171,7 @@ class FGSCountrate:
             switcher = OrderedDict([
                 (i, 'convert_tmass_to_jhk'),
                 ('SDSSgMag, SDSSzMag',  'convert_sdssgz_to_jhk'),
+                ('SDSSrMag, SDSSzMag', 'convert_sdssrz_to_jhk'),
                 ('SDSSgMag, SDSSiMag',  'convert_sdssgi_to_jhk'),
                 ('SDSSiMag, SDSSzMag',  'convert_sdssiz_to_jhk'),
                 ('JpgMag, NpgMag',      'convert_gsc2bjin_to_jhk'),

--- a/fgscountrate/fgs_countrate_core.py
+++ b/fgscountrate/fgs_countrate_core.py
@@ -178,7 +178,7 @@ class FGSCountrate:
                 ('SDSSgMag, SDSSzMag',  'convert_sdssgz_to_jhk'),
                 ('SDSSrMag, SDSSzMag', 'convert_sdssrz_to_jhk'),
                 ('SDSSgMag, SDSSiMag',  'convert_sdssgi_to_jhk'),
-                ('SDSSiMag, SDSSzMag',  'convert_sdssiz_to_jhk'),
+                #('SDSSiMag, SDSSzMag',  'convert_sdssiz_to_jhk'), # Add back in once GSSS uses this pair
                 ('JpgMag, NpgMag',      'convert_gsc2bjin_to_jhk'),
                 ('FpgMag, NpgMag',      'convert_gsc2rfin_to_jhk'),
                 ('JpgMag, FpgMag',      'convert_gsc2bjrf_to_jhk'),

--- a/fgscountrate/fgs_countrate_core.py
+++ b/fgscountrate/fgs_countrate_core.py
@@ -264,25 +264,6 @@ class FGSCountrate:
         self.h_mag, self.h_mag_err = method_list[1](data=edited_data_series, output_mag='H')
         self.k_mag, self.k_mag_err = method_list[2](data=edited_data_series, output_mag='K')
 
-        # Create new attributes with updated series
-        # Choose either SDSS or GSC - don't include both, to match GSSS
-        if True in ['sdss' in substring.lower() for substring in self._present_queried_mags]:
-            l = [band for band in GSC_BAND_NAMES if 'tmass' in band.lower() or 'sdss' in band.lower()]
-        elif True in ['gsc' in substring.lower() for substring in self._present_queried_mags]:
-            l = [band for band in GSC_BAND_NAMES if 'tmass' in band.lower() or 'gsc' in band.lower()]
-        else:
-            l = [band for band in GSC_BAND_NAMES if 'tmass' in band.lower()]
-
-        self._all_calculated_mag_series = self._all_queried_mag_series.loc[l]
-        self._all_calculated_mag_err_series = self._all_queried_mag_err_series.loc[[name+'Err' for name in l]]
-        self._present_calculated_mags = l
-
-        # Add J, H, and K values
-        self._all_calculated_mag_series.loc[['tmassJMag', 'tmassHMag', 'tmassKsMag']] = \
-            self.j_mag, self.h_mag, self.k_mag
-        self._all_calculated_mag_err_series.loc[['tmassJMagErr', 'tmassHMagErr', 'tmassKsMagErr']] = \
-            self.j_mag_err, self.h_mag_err, self.k_mag_err
-
         return self.j_mag, self.j_mag_err, self.h_mag, self.h_mag_err, self.k_mag, self.k_mag_err
 
     def _calc_fgs_cr_mag(self, to_compute, band_series, guider_throughput, guider_gain, return_dataframe=False):
@@ -434,6 +415,25 @@ class FGSCountrate:
         # Set values based on guider
         throughput_dict = globals()['THROUGHPUT_G{}'.format(self.guider)]
         cr_conversion = globals()['CR_CONVERSION_G{}'.format(self.guider)]
+
+        # Create new attributes with updated series
+        # Choose either SDSS or GSC - don't include both, to match GSSS
+        if True in ['sdss' in substring.lower() for substring in self._present_queried_mags]:
+            l = [band for band in GSC_BAND_NAMES if 'tmass' in band.lower() or 'sdss' in band.lower()]
+        elif True in ['gsc' in substring.lower() for substring in self._present_queried_mags]:
+            l = [band for band in GSC_BAND_NAMES if 'tmass' in band.lower() or 'gsc' in band.lower()]
+        else:
+            l = [band for band in GSC_BAND_NAMES if 'tmass' in band.lower()]
+
+        self._all_calculated_mag_series = self._all_queried_mag_series.loc[l]
+        self._all_calculated_mag_err_series = self._all_queried_mag_err_series.loc[[name+'Err' for name in l]]
+        self._present_calculated_mags = l
+
+        # Update any calculated J, H, and K values
+        self._all_calculated_mag_series.loc[['tmassJMag', 'tmassHMag', 'tmassKsMag']] = \
+            self.j_mag, self.h_mag, self.k_mag
+        self._all_calculated_mag_err_series.loc[['tmassJMagErr', 'tmassHMagErr', 'tmassKsMagErr']] = \
+            self.j_mag_err, self.h_mag_err, self.k_mag_err
 
         # Calculate magnitude/countrate
         self.fgs_countrate, self.fgs_magnitude, self.band_dataframe = \

--- a/fgscountrate/fgs_countrate_core.py
+++ b/fgscountrate/fgs_countrate_core.py
@@ -174,7 +174,7 @@ class FGSCountrate:
         if len(data_frame) == 1:
             self.gsc_series = data_frame.iloc[0]
         else:
-            raise ValueError("This Guide Star ID points to multiple lines in {}".format(catalog))
+            raise ValueError(f"This Guide Star ID points to multiple lines in {catalog}")
 
         # Convert to JHK magnitudes
         self.j_mag, self.j_mag_err, self.h_mag, self.h_mag_err, self.k_mag, self.k_mag_err = \
@@ -246,15 +246,15 @@ class FGSCountrate:
                         continue
 
                     # Set the conversion method
-                    setattr(self, '{}_convert_method'.format(i[5].lower()), value)
+                    setattr(self, f'{i[5].lower()}_convert_method', value)
                     break
 
             # Return -999 if the band cannot be calculated
-            if getattr(self, '{}_convert_method'.format(i[5].lower())) is None:
-                setattr(self, '{}_convert_method'.format(i[5].lower()), 'cannot_calculate')
+            if getattr(self, f'{i[5].lower()}_convert_method') is None:
+                setattr(self, f'{i[5].lower()}_convert_method', 'cannot_calculate')
 
             # Get the method
-            method = getattr(conversions, getattr(self, '{}_convert_method'.format(i[5].lower())), lambda: "Invalid")
+            method = getattr(conversions, getattr(self, f'{i[5].lower()}_convert_method'), lambda: "Invalid")
             method_list.append(method)
 
         # Create a new series with the edited data (in case uncertainties were replaced)
@@ -360,8 +360,8 @@ class FGSCountrate:
 
         # Can't compute if we only have J, H, and K  # TODO will be changed later
         if {'tmassJMag', 'tmassHMag', 'tmassKsMag'} == set(self._present_calculated_mags):
-            raise ValueError('Cannot compute FGS countrate & magnitude for a guide star ({}) with only 2MASS '
-                             'data'.format(self.id))
+            raise ValueError(f'Cannot compute FGS countrate & magnitude for a guide star ({self.id}) with only 2MASS '
+                             'data')
 
         # Reset the shortest/2nd shortest bands to 0 if they are missing
         if df.at['JpgMag', 'Signal'] == -999:
@@ -383,7 +383,7 @@ class FGSCountrate:
 
         # Compute FGS magnitude
         sum_throughput = utils.trapezoid_sum(df_short, 'Throughput')
-        mag_conversion = globals()['MAG_CONVERSION_G{}'.format(self.guider)]
+        mag_conversion = globals()[f'MAG_CONVERSION_G{self.guider}']
         fgs_magnitude = -2.5 * np.log10(electrons / sum_throughput) + mag_conversion
 
         if to_compute.lower() == 'magnitude' or to_compute.lower() == 'both':
@@ -414,8 +414,8 @@ class FGSCountrate:
         """
 
         # Set values based on guider
-        throughput_dict = globals()['THROUGHPUT_G{}'.format(self.guider)]
-        cr_conversion = globals()['CR_CONVERSION_G{}'.format(self.guider)]
+        throughput_dict = globals()[f'THROUGHPUT_G{self.guider}']
+        cr_conversion = globals()[f'CR_CONVERSION_G{self.guider}']
 
         # Create new attributes with updated series
         # Choose either SDSS or GSC - don't include both, to match GSSS
@@ -538,9 +538,9 @@ def get_conversion_constants(guider):
     guider : int
         The guider number, either 1 or 2
     """
-    cr_conversion = globals()['CR_CONVERSION_G{}'.format(guider)]
-    throughput = globals()['THROUGHPUT_G{}'.format(guider)]
-    mag_conversion = globals()['MAG_CONVERSION_G{}'.format(guider)]
+    cr_conversion = globals()[f'CR_CONVERSION_G{guider}']
+    throughput = globals()[f'THROUGHPUT_G{guider}']
+    mag_conversion = globals()[f'MAG_CONVERSION_G{guider}']
 
     df = pd.DataFrame(throughput.items(), index=np.arange(len(throughput)), columns=['Wavelength', 'Throughput'])
     sum_throughput = utils.trapezoid_sum(df, 'Throughput')

--- a/fgscountrate/fgs_countrate_core.py
+++ b/fgscountrate/fgs_countrate_core.py
@@ -184,10 +184,14 @@ class FGSCountrate:
 
                 if set(key_list).issubset(self._present_queried_mags):
 
-                    # Check for faint star limits
                     mags = self._all_queried_mag_series[key_list].values
+                    # Check for faint star limits
                     if utils.check_band_below_faint_limits(key_list, mags):
                         continue
+                    # Check if SDSS-GZ has okay limits
+                    if key == 'SDSSgMag, SDSSzMag':
+                        if utils.check_sdss_gz_limits(mags):
+                            continue
 
                     # Set the conversion method
                     setattr(self, f'{i[5].lower()}_convert_method', value)

--- a/fgscountrate/fgs_countrate_core.py
+++ b/fgscountrate/fgs_countrate_core.py
@@ -230,18 +230,14 @@ class FGSCountrate:
                                                                       if a not in self._present_queried_mags]
 
         # Set survey to use if available from conversion information
-        if ('sdss' in self.j_convert_method) or ('sdss' in self.h_convert_method) or ('sdss' in self.k_convert_method):
+        # If one of the SDSS pairs is present
+        if set(['SDSSgMag', 'SDSSzMag']).issubset(set(self._present_calculated_mags)) or \
+           set(['SDSSrMag', 'SDSSzMag']).issubset(set(self._present_calculated_mags)) or \
+           set(['SDSSgMag', 'SDSSiMag']).issubset(set(self._present_calculated_mags)):
             self.survey = 'sdss'
-        elif ('gsc2' in self.j_convert_method) or ('gsc2' in self.h_convert_method) or ('gsc2' in self.k_convert_method):
+        # If you don't have any SDSS pairs but you do have GSC2 data
+        else:
             self.survey = 'gsc2'
-        else: # if jhk were all from tmass
-            if True in ['sdss' in substring.lower() for substring in self._present_calculated_mags]:
-                self.survey = 'sdss'
-            elif True in ['pgmag' in substring.lower() for substring in self._present_calculated_mags]:
-                # GSC2 bands are named with pgmag
-                self.survey = 'gsc2'
-            else:
-                self.survey = 'tmass'
 
         return self.j_mag, self.j_mag_err, self.h_mag, self.h_mag_err, self.k_mag, self.k_mag_err
 
@@ -405,9 +401,6 @@ class FGSCountrate:
         elif self.survey == 'gsc2':
             all_list = [band for band in GSC_BAND_NAMES if 'tmass' in band.lower() or 'pgmag' in band.lower()]
             present_list = [band for band in self._present_calculated_mags if 'tmass' in band.lower() or 'pgmag' in band.lower()]
-        elif self.survey == 'tmass':
-            all_list = [band for band in GSC_BAND_NAMES if 'tmass' in band.lower()]
-            present_list = [band for band in self._present_calculated_mags if 'tmass' in band.lower()]
         self._all_calculated_mag_series = self._all_calculated_mag_series.loc[all_list]
         self._all_calculated_mag_err_series = self._all_calculated_mag_err_series.loc[[name+'Err' for name in all_list]]
         self._present_calculated_mags = present_list

--- a/fgscountrate/fgs_countrate_core.py
+++ b/fgscountrate/fgs_countrate_core.py
@@ -372,11 +372,6 @@ class FGSCountrate:
 
         df['Signal'] = df.apply(lambda row: calc_signal(row), axis=1)
 
-        # Can't compute if we only have J, H, and K  # TODO will be changed later
-        if {'tmassJMag', 'tmassHMag', 'tmassKsMag'} == set(self._present_calculated_mags):
-            raise ValueError(f'Cannot compute FGS countrate & magnitude for a guide star ({self.id}) with only 2MASS '
-                             'data')
-
         # Reset the shortest/2nd shortest bands to 0 if they are missing
         if 'JpgMag' in df.index and df.at['JpgMag', 'Signal'] == -999:
             df.at['JpgMag', 'Signal'] = 0

--- a/fgscountrate/fgs_countrate_core.py
+++ b/fgscountrate/fgs_countrate_core.py
@@ -372,11 +372,13 @@ class FGSCountrate:
 
         df['Signal'] = df.apply(lambda row: calc_signal(row), axis=1)
 
-        # Reset the shortest/2nd shortest bands to 0 if they are missing
-        if 'JpgMag' in df.index and df.at['JpgMag', 'Signal'] == -999:
-            df.at['JpgMag', 'Signal'] = 0
-        if 'SDSSgMag' in df.index and df.at['SDSSgMag', 'Signal'] == -999:
-            df.at['SDSSgMag', 'Signal'] = 0
+        # Commenting out to match GSS code - may add back in later
+        # Also SDSSu is lower than SDSSg, so why did we do this with g?
+        # # Reset the shortest/2nd shortest bands to 0 if they are missing
+        # if 'JpgMag' in df.index and df.at['JpgMag', 'Signal'] == -999:
+        #     df.at['JpgMag', 'Signal'] = 0
+        # if 'SDSSgMag' in df.index and df.at['SDSSgMag', 'Signal'] == -999:
+        #     df.at['SDSSgMag', 'Signal'] = 0
 
         # Throw out any bands for which you don't have data
         df_short = df[df['Signal'] != -999]

--- a/fgscountrate/fgs_countrate_core.py
+++ b/fgscountrate/fgs_countrate_core.py
@@ -234,6 +234,14 @@ class FGSCountrate:
             self.survey = 'sdss'
         elif ('gsc2' in self.j_convert_method) or ('gsc2' in self.h_convert_method) or ('gsc2' in self.k_convert_method):
             self.survey = 'gsc2'
+        else: # if jhk were all from tmass
+            if True in ['sdss' in substring.lower() for substring in self._present_calculated_mags]:
+                self.survey = 'sdss'
+            elif True in ['pgmag' in substring.lower() for substring in self._present_calculated_mags]:
+                # GSC2 bands are named with pgmag
+                self.survey = 'gsc2'
+            else:
+                self.survey = 'tmass'
 
         return self.j_mag, self.j_mag_err, self.h_mag, self.h_mag_err, self.k_mag, self.k_mag_err
 
@@ -389,15 +397,6 @@ class FGSCountrate:
         # Set values based on guider
         throughput_dict = globals()[f'THROUGHPUT_G{self.guider}']
         cr_conversion = globals()[f'CR_CONVERSION_G{self.guider}']
-
-        # Define survey to use if not already defined (previous definition is the better way to do it)
-        if self.survey is None:
-            if True in ['sdss' in substring.lower() for substring in self._present_calculated_mags]:
-                self.survey = 'sdss'
-            elif True in ['pgmag' in substring.lower() for substring in self._present_calculated_mags]:
-                self.survey = 'gsc2'
-            else:
-                self.survey = 'tmass'
 
         # Update attributes with updated series - choose either SDSS or GSC - don't include both, to match GSSS
         if self.survey == 'sdss':

--- a/fgscountrate/fgs_countrate_core.py
+++ b/fgscountrate/fgs_countrate_core.py
@@ -329,7 +329,7 @@ class FGSCountrate:
 
         df['Signal'] = df.apply(lambda row: calc_signal(row), axis=1)
 
-        # Commenting out to match GSS code - may add back in later
+        # Commenting out to match GSSS code - may add back in later
         # Also SDSSu is lower than SDSSg, so why did we do this with g?
         # # Reset the shortest/2nd shortest bands to 0 if they are missing
         # if 'JpgMag' in df.index and df.at['JpgMag', 'Signal'] == -999:

--- a/fgscountrate/fgs_countrate_core.py
+++ b/fgscountrate/fgs_countrate_core.py
@@ -164,6 +164,10 @@ class FGSCountrate:
         # List of the magnitude names that are not fill values in the series
         self._present_queried_mags = list(self._all_queried_mag_series[self._all_queried_mag_series != -999].index)
 
+        # Remove all dim bands
+        self._present_queried_mags = utils.check_band_below_faint_limits(self._present_queried_mags,
+                                     self._all_queried_mag_series[self._present_queried_mags].tolist())
+
         # Dictionary of convert methods
         tmass_list = ['tmassJMag', 'tmassHMag', 'tmassKsMag']
         method_list = []
@@ -186,9 +190,7 @@ class FGSCountrate:
                 if set(key_list).issubset(self._present_queried_mags):
 
                     mags = self._all_queried_mag_series[key_list].values
-                    # Check for faint star limits
-                    if utils.check_band_below_faint_limits(key_list, mags):
-                        continue
+
                     # Check if SDSS-GZ has okay limits
                     if key == 'SDSSgMag, SDSSzMag':
                         if utils.check_sdss_gz_limits(mags):

--- a/fgscountrate/fgs_countrate_core.py
+++ b/fgscountrate/fgs_countrate_core.py
@@ -192,10 +192,10 @@ class FGSCountrate:
 
                     mags = self._all_queried_mag_series[key_list].values
 
-                    # Check if SDSS-GZ has okay limits
-                    if key == 'SDSSgMag, SDSSzMag':
-                        if utils.check_sdss_gz_limits(mags):
-                            continue
+                    # Check color differences - commented out until it's added to GSSS
+                    # if key == 'SDSSgMag, SDSSzMag':
+                    #     if utils.check_sdss_gz_limits(mags):
+                    #         continue
 
                     # Set the conversion method
                     setattr(self, f'{i[5].lower()}_convert_method', value)

--- a/fgscountrate/fgs_countrate_core.py
+++ b/fgscountrate/fgs_countrate_core.py
@@ -289,6 +289,11 @@ class FGSCountrate:
         # Sort to order of increasing wavelength
         df = df.sort_values(by=['Wavelength'])
 
+        # Check that you don't have any negative magnitude values
+        if True in [i < 0 for i in df[df['Mag'] != -999]['Mag'].values]:
+            raise ValueError('This star has negative magnitude values and cannot be used to '
+                             'calculate a meaningful count rate and magnitude.')
+
         # Calculate and add ABMagnitudes
         def ab_mag(row):
             if row.name in self._present_calculated_mags:

--- a/fgscountrate/fgs_countrate_core.py
+++ b/fgscountrate/fgs_countrate_core.py
@@ -20,64 +20,7 @@ import pandas as pd
 
 from . import conversions
 from . import utils
-
-# Universal Constant
-PLANCK = 6.625e-27
-
-# GSC Band Information
-GSC_BAND_NAMES = ['tmassJMag', 'tmassHMag', 'tmassKsMag',
-                  'SDSSuMag', 'SDSSgMag', 'SDSSrMag', 'SDSSiMag',
-                  'SDSSzMag', 'JpgMag', 'FpgMag', 'NpgMag']
-GSC_BAND_WAVELENGTH = [1.25, 1.65, 2.17,
-                       0.3551, 0.4680, 0.6166, 0.7480,
-                       0.8932, 0.4660, 0.6450, 0.8500]
-
-# Factor to use when calculating a band's missing uncertainty
-BAND_ERR = 0.025
-
-# FGS-Guider + OTE throughput
-THROUGHPUT_G1 = {
-    0.3551: 0.0,
-    0.4660: 0.042,
-    0.4680: 0.044,
-    0.6166: 0.389,
-    0.6450: 0.487,
-    0.7480: 0.586,
-    0.8500: 0.655,
-    0.8932: 0.707,
-    1.25: 0.688,
-    1.65: 0.633,
-    2.17: 0.723,
-    3.0: 0.744,
-    4.0: 0.690,
-    5.0: 0.548,
-    5.5: 0.041,
-}
-THROUGHPUT_G2 = {
-    0.3551: 0.0,
-    0.4660: 0.020,
-    0.4680: 0.021,
-    0.6166: 0.289,
-    0.6450: 0.390,
-    0.7480: 0.628,
-    0.8500: 0.669,
-    0.8932: 0.647,
-    1.25: 0.761,
-    1.65: 0.603,
-    2.17: 0.635,
-    3.0: 0.735,
-    4.0: 0.738,
-    5.0: 0.687,
-    5.5: 0.040,
-}
-
-# Countrate conversion factors
-CR_CONVERSION_G1 = 1.74
-CR_CONVERSION_G2 = 1.57
-
-# Magnitude conversion constant
-MAG_CONVERSION_G1 = 28.29
-MAG_CONVERSION_G2 = 28.20
+from .constants import *
 
 
 class FGSCountrate:

--- a/fgscountrate/fgs_countrate_core.py
+++ b/fgscountrate/fgs_countrate_core.py
@@ -249,8 +249,9 @@ class FGSCountrate:
                     setattr(self, '{}_convert_method'.format(i[5].lower()), value)
                     break
 
+            # Return -999 if the band cannot be calculated
             if getattr(self, '{}_convert_method'.format(i[5].lower())) is None:
-                raise ValueError('There is not enough information on this guide star to get its {} magnitude'.format(i))
+                setattr(self, '{}_convert_method'.format(i[5].lower()), 'cannot_calculate')
 
             # Get the method
             method = getattr(conversions, getattr(self, '{}_convert_method'.format(i[5].lower())), lambda: "Invalid")

--- a/fgscountrate/fgs_countrate_core.py
+++ b/fgscountrate/fgs_countrate_core.py
@@ -264,18 +264,24 @@ class FGSCountrate:
         self.h_mag, self.h_mag_err = method_list[1](data=edited_data_series, output_mag='H')
         self.k_mag, self.k_mag_err = method_list[2](data=edited_data_series, output_mag='K')
 
-        # Create new attribute with updated series
-        self._all_calculated_mag_series = copy.deepcopy(self._all_queried_mag_series)
+        # Create new attributes with updated series
+        # Choose either SDSS or GSC - don't include both, to match GSSS
+        if True in ['sdss' in substring.lower() for substring in self._present_queried_mags]:
+            l = [band for band in GSC_BAND_NAMES if 'tmass' in band.lower() or 'sdss' in band.lower()]
+        elif True in ['gsc' in substring.lower() for substring in self._present_queried_mags]:
+            l = [band for band in GSC_BAND_NAMES if 'tmass' in band.lower() or 'gsc' in band.lower()]
+        else:
+            l = [band for band in GSC_BAND_NAMES if 'tmass' in band.lower()]
+
+        self._all_calculated_mag_series = self._all_queried_mag_series.loc[l]
+        self._all_calculated_mag_err_series = self._all_queried_mag_err_series.loc[[name+'Err' for name in l]]
+        self._present_calculated_mags = l
+
+        # Add J, H, and K values
         self._all_calculated_mag_series.loc[['tmassJMag', 'tmassHMag', 'tmassKsMag']] = \
             self.j_mag, self.h_mag, self.k_mag
-
-        self._all_calculated_mag_err_series = copy.deepcopy(self._all_queried_mag_err_series)
         self._all_calculated_mag_err_series.loc[['tmassJMagErr', 'tmassHMagErr', 'tmassKsMagErr']] = \
             self.j_mag_err, self.h_mag_err, self.k_mag_err
-
-        self._present_calculated_mags = self._present_queried_mags + [a for a in
-                                                                      ['tmassJMag', 'tmassHMag', 'tmassKsMag']
-                                                                      if a not in self._present_queried_mags]
 
         return self.j_mag, self.j_mag_err, self.h_mag, self.h_mag_err, self.k_mag, self.k_mag_err
 

--- a/fgscountrate/fgs_countrate_core.py
+++ b/fgscountrate/fgs_countrate_core.py
@@ -425,16 +425,20 @@ class FGSCountrate:
             l = [band for band in GSC_BAND_NAMES if 'tmass' in band.lower() or 'gsc' in band.lower()]
         else:
             l = [band for band in GSC_BAND_NAMES if 'tmass' in band.lower()]
-
         self._all_calculated_mag_series = self._all_queried_mag_series.loc[l]
         self._all_calculated_mag_err_series = self._all_queried_mag_err_series.loc[[name+'Err' for name in l]]
-        self._present_calculated_mags = l
-
+        self._present_calculated_mags = list(self._all_calculated_mag_series[self._all_calculated_mag_series
+                                                                             != -999].index)
         # Update any calculated J, H, and K values
         self._all_calculated_mag_series.loc[['tmassJMag', 'tmassHMag', 'tmassKsMag']] = \
             self.j_mag, self.h_mag, self.k_mag
         self._all_calculated_mag_err_series.loc[['tmassJMagErr', 'tmassHMagErr', 'tmassKsMagErr']] = \
             self.j_mag_err, self.h_mag_err, self.k_mag_err
+
+        # Check if we need to skip the star - if still missing J or K, cannot compute values for star
+        if 'tmassJMag' not in self._present_calculated_mags or 'tmassKsMag' not in self._present_calculated_mags:
+            raise ValueError(f'Cannot compute FGS countrate & magnitude for a guide star {self.id} '
+                             f'because it is missing too many bands.')
 
         # Calculate magnitude/countrate
         self.fgs_countrate, self.fgs_magnitude, self.band_dataframe = \

--- a/fgscountrate/tests/test_calc_cr_mag.py
+++ b/fgscountrate/tests/test_calc_cr_mag.py
@@ -167,9 +167,9 @@ def test_dim_limits_partialsdss():
     fgs.gsc_series = copy.copy(GSC_SERIES)
     for ind in TMASS_BANDS:
         fgs.gsc_series.loc[ind] = -999
-    fgs.gsc_series['SDSSgMag'] = 24  # dim
+    fgs.gsc_series['SDSSgMag'] = 17
     fgs.gsc_series['SDSSrMag'] = 24  # dim
-    fgs.gsc_series['SDSSzMag'] = 17
+    fgs.gsc_series['SDSSzMag'] = 24  # dim
     fgs.gsc_series['SDSSiMag'] = 17
 
     # Convert to JHK magnitudes
@@ -177,9 +177,9 @@ def test_dim_limits_partialsdss():
         fgs.calc_jhk_mag(fgs.gsc_series)
 
     # Check conversion method
-    assert fgs.j_convert_method == 'convert_sdssiz_to_jhk'
-    assert fgs.h_convert_method == 'convert_sdssiz_to_jhk'
-    assert fgs.k_convert_method == 'convert_sdssiz_to_jhk'
+    assert fgs.j_convert_method == 'convert_sdssgi_to_jhk'
+    assert fgs.h_convert_method == 'convert_sdssgi_to_jhk'
+    assert fgs.k_convert_method == 'convert_sdssgi_to_jhk'
 
     # Compute FGS countrate and magnitude to get fgs.band_dataframe attribute
     _ = fgs.calc_fgs_cr_mag_and_err()
@@ -187,9 +187,9 @@ def test_dim_limits_partialsdss():
     # Check Mag, ABMag, Flux, and Signal = -999 for g and r
     assert fgs.survey == 'sdss'
 
-    assert fgs.band_dataframe.at['SDSSgMag', 'ABMag'] == -999
-    assert fgs.band_dataframe.at['SDSSgMag', 'Flux'] == -999
-    assert fgs.band_dataframe.at['SDSSgMag', 'Signal'] == -999
+    assert fgs.band_dataframe.at['SDSSzMag', 'ABMag'] == -999
+    assert fgs.band_dataframe.at['SDSSzMag', 'Flux'] == -999
+    assert fgs.band_dataframe.at['SDSSzMag', 'Signal'] == -999
 
     assert fgs.band_dataframe.at['SDSSrMag', 'ABMag'] == -999
     assert fgs.band_dataframe.at['SDSSrMag', 'Flux'] == -999

--- a/fgscountrate/tests/test_calc_cr_mag.py
+++ b/fgscountrate/tests/test_calc_cr_mag.py
@@ -120,55 +120,6 @@ def test_convert_fgs_mag_to_cr():
     assert np.isclose(cr, expected_cr, 1)
 
 
-def test_faint_limits():
-    """Test that when SDSSgMag is below the faint limit, that conversion is skipped"""
-
-    gs_id = 'N13I000018'
-    guider = 1
-    fgs = FGSCountrate(guide_star_id=gs_id, guider=guider)
-
-    # Reset data to a set of constant, fake data with SDSS_g too dim and tmass missing
-    fgs.gsc_series = GSC_SERIES
-    fgs.gsc_series['tmassJMag'] = -999
-    fgs.gsc_series['tmassHMag'] = -999
-    fgs.gsc_series['tmassKsMag'] = -999
-    fgs.gsc_series['SDSSgMag'] = 25
-
-    # Convert to JHK magnitudes
-    fgs.j_mag, fgs.j_mag_err, fgs.h_mag, fgs.h_mag_err, fgs.k_mag, fgs.k_mag_err = \
-        fgs.calc_jhk_mag(fgs.gsc_series)
-
-    # Check that the conversion methods are the SDSS ones that don't include SDSS_g
-    assert fgs.j_convert_method == 'convert_sdssiz_to_jhk'
-    assert fgs.h_convert_method == 'convert_sdssiz_to_jhk'
-    assert fgs.k_convert_method == 'convert_sdssiz_to_jhk'
-
-
-def test_bad_sdss_gz_limits():
-    """Test that when SDSSgMag and SDSSzMag color differences are bad, that conversion is skipped"""
-
-    gs_id = 'N13I000018'
-    guider = 1
-    fgs = FGSCountrate(guide_star_id=gs_id, guider=guider)
-
-    # Reset data to a set of constant, fake data with SDSS_g and z having bad color ranges and tmass missing
-    fgs.gsc_series = GSC_SERIES
-    fgs.gsc_series['tmassJMag'] = -999
-    fgs.gsc_series['tmassHMag'] = -999
-    fgs.gsc_series['tmassKsMag'] = -999
-    fgs.gsc_series['SDSSgMag'] = 20
-    fgs.gsc_series['SDSSzMag'] = 14
-
-    # Convert to JHK magnitudes
-    fgs.j_mag, fgs.j_mag_err, fgs.h_mag, fgs.h_mag_err, fgs.k_mag, fgs.k_mag_err = \
-        fgs.calc_jhk_mag(fgs.gsc_series)
-
-    # Check that the conversion methods is the SDSS one after SDSS g-z
-    assert fgs.j_convert_method == 'convert_sdssgi_to_jhk'
-    assert fgs.h_convert_method == 'convert_sdssgi_to_jhk'
-    assert fgs.k_convert_method == 'convert_sdssgi_to_jhk'
-
-
 def test_band_missing():
     """Test that when a band (SDSS_g) is missing, it's signal is set to 0"""
 

--- a/fgscountrate/tests/test_calc_cr_mag.py
+++ b/fgscountrate/tests/test_calc_cr_mag.py
@@ -389,6 +389,7 @@ def test_errors():
     fgs._all_calculated_mag_series = fgs.gsc_series.loc[fgscountrate.fgs_countrate_core.GSC_BAND_NAMES]
     fgs._all_calculated_mag_err_series = fgs.gsc_series.loc[[band+'Err' for band
                                                              in fgscountrate.fgs_countrate_core.GSC_BAND_NAMES]]
+    fgs.survey = 'tmass'
 
     with pytest.raises(ValueError) as excinfo:
         fgs.calc_fgs_cr_mag_and_err()
@@ -416,6 +417,7 @@ def test_output_options():
     fgs._all_calculated_mag_series = fgs.gsc_series.loc[fgscountrate.GSC_BAND_NAMES]
     mag_err_list = [fgs.gsc_series[ind + 'Err'] for ind in fgs._all_calculated_mag_series.index]
     fgs._all_calculated_mag_err_series = pd.Series(mag_err_list, index=fgs._all_calculated_mag_series.index+'Err')
+    fgs.survey = 'sdss'
 
     # Test output from calc_fgs_cr_mag_and_err()
     return_list = fgs.calc_fgs_cr_mag_and_err()

--- a/fgscountrate/tests/test_convert_jhk.py
+++ b/fgscountrate/tests/test_convert_jhk.py
@@ -155,6 +155,7 @@ def test_check_band_below_faint_limits_failure():
     assert 'Cannot compute FGS countrate & magnitude for a guide star' in str(e_info.value)
 
 
+@pytest.mark.skip(reason="Removed test until this functionality is added back into the GSSS and this code")
 def test_bad_sdss_gz_limits():
     """Test that when SDSSgMag and SDSSzMag color differences are bad, that conversion is skipped"""
 

--- a/fgscountrate/tests/test_convert_jhk.py
+++ b/fgscountrate/tests/test_convert_jhk.py
@@ -65,18 +65,18 @@ def test_convert_mag_to_jhk():
                 if i in list(subset):
                     method_name_test = "convert_tmass_to_jhk"
 
-                elif set(['SDSSgMag', 'SDSSzMag']).issubset(subset):
+                elif {'SDSSgMag', 'SDSSzMag'}.issubset(subset):
                     method_name_test = "convert_sdssgz_to_jhk"
-                elif set(['SDSSgMag', 'SDSSiMag']).issubset(subset):
+                elif {'SDSSgMag', 'SDSSiMag'}.issubset(subset):
                     method_name_test = "convert_sdssgi_to_jhk"
-                elif set(['SDSSiMag', 'SDSSzMag']).issubset(subset):
+                elif {'SDSSiMag', 'SDSSzMag'}.issubset(subset):
                     method_name_test = "convert_sdssiz_to_jhk"
 
-                elif set(['JpgMag', 'NpgMag']).issubset(subset):
+                elif {'JpgMag', 'NpgMag'}.issubset(subset):
                     method_name_test = "convert_gsc2bjin_to_jhk"
-                elif set(['FpgMag', 'NpgMag']).issubset(subset):
+                elif {'FpgMag', 'NpgMag'}.issubset(subset):
                     method_name_test = "convert_gsc2rfin_to_jhk"
-                elif set(['JpgMag', 'FpgMag']).issubset(subset):
+                elif {'JpgMag', 'FpgMag'}.issubset(subset):
                     method_name_test = "convert_gsc2bjrf_to_jhk"
 
                 else:
@@ -84,18 +84,18 @@ def test_convert_mag_to_jhk():
 
                 method_names.append(method_name_test)
 
-                if method_name_test != getattr(fgs, '{}_convert_method'.format(i[5].lower())):
+                if method_name_test != getattr(fgs, f'{i[5].lower()}_convert_method'):
                     if error is False:
                         print(subset)
-                        print("    **", error, method_name_test, getattr(fgs, '{}_convert_method'.format(i[5].lower())))
+                        print("    **", error, method_name_test, getattr(fgs, f'{i[5].lower()}_convert_method'))
 
                 # If you could compute the JHK mags, check the same conversion method as used
                 if error is False:
-                    failure_message = 'For input {} and band {}: the test called {} while the calc_jhk_mag ' \
-                                      'method called {}'.format(list(subset), i[5], method_name_test,
-                                                                getattr(fgs, '{}_convert_method'.format(i[5].lower())))
+                    failure_message = f'For input {list(subset)} and band {i[5]}: the test called {method_name_test} ' \
+                                      f'while the calc_jhk_mag method called ' \
+                                      f'{getattr(fgs, f"{i[5].lower()}_convert_method")}'
 
-                    assert method_name_test == getattr(fgs, '{}_convert_method'.format(i[5].lower())), failure_message
+                    assert method_name_test == getattr(fgs, f'{i[5].lower()}_convert_method'), failure_message
 
             # If you can't compute the JHK mags, check methods agree it's not possible
             if error is True:

--- a/fgscountrate/tests/test_convert_jhk.py
+++ b/fgscountrate/tests/test_convert_jhk.py
@@ -63,6 +63,8 @@ def test_convert_mag_to_jhk():
 
                 elif {'SDSSgMag', 'SDSSzMag'}.issubset(subset):
                     method_name_test = "convert_sdssgz_to_jhk"
+                elif {'SDSSrMag', 'SDSSzMag'}.issubset(subset):
+                    method_name_test = "convert_sdssrz_to_jhk"
                 elif {'SDSSgMag', 'SDSSiMag'}.issubset(subset):
                     method_name_test = "convert_sdssgi_to_jhk"
                 elif {'SDSSiMag', 'SDSSzMag'}.issubset(subset):
@@ -88,16 +90,16 @@ def test_convert_mag_to_jhk():
 
 
 testdata = [
-    (15, 15, 15, 25, 25, 25, 'convert_tmass_to_jhk', 'convert_tmass_to_jhk', 'convert_tmass_to_jhk'),
-    (-999, -999, -999, 25, 15, 15, 'convert_sdssiz_to_jhk', 'convert_sdssiz_to_jhk', 'convert_sdssiz_to_jhk'),
+    (15, 15, 15, 25, 25, 25, 25, 'convert_tmass_to_jhk', 'convert_tmass_to_jhk', 'convert_tmass_to_jhk'),
+    (-999, -999, -999, 25, 15, 25, 15, 'convert_sdssiz_to_jhk', 'convert_sdssiz_to_jhk', 'convert_sdssiz_to_jhk'),
 ]
 ids = ['tmass conversion with faint sdss', 'sdss-zi conversion because of faint g-band']
-@pytest.mark.parametrize("jmag, hmag, kmag, gmag, zmag, imag, convert_j, convert_h, convert_k", testdata, ids=ids)
-def test_check_band_below_faint_limits_pass(jmag, hmag, kmag, gmag, zmag, imag, convert_j, convert_h, convert_k):
+@pytest.mark.parametrize("jmag, hmag, kmag, gmag, zmag, rmag, imag, convert_j, convert_h, convert_k", testdata, ids=ids)
+def test_check_band_below_faint_limits_pass(jmag, hmag, kmag, gmag, zmag, rmag, imag, convert_j, convert_h, convert_k):
     """
     Test that the checking of faint bands will in certain cases have the code
     choose a conversion method that is not the "best" case conversion because
-    of the existense of faint stars.
+    of the existence of faint stars.
     """
     # Edit base data for specific test
     data = copy.copy(BASE_DATA)
@@ -105,6 +107,7 @@ def test_check_band_below_faint_limits_pass(jmag, hmag, kmag, gmag, zmag, imag, 
     data['tmassHMag'] = hmag
     data['tmassKsMag'] = kmag
     data['SDSSgMag'] = gmag
+    data['SDSSrMag'] = rmag
     data['SDSSzMag'] = zmag
     data['SDSSiMag'] = imag
     data['JpgMag'] = -999
@@ -132,6 +135,7 @@ def test_check_band_below_faint_limits_failure():
     data['tmassHMag'] = -999
     data['tmassKsMag'] = -999
     data['SDSSgMag'] = 25
+    data['SDSSrMag'] = -999
     data['SDSSzMag'] = 25
     data['SDSSiMag'] = 15
     data['JpgMag'] = -999

--- a/fgscountrate/tests/test_convert_jhk.py
+++ b/fgscountrate/tests/test_convert_jhk.py
@@ -67,8 +67,8 @@ def test_convert_mag_to_jhk():
                     method_name_test = "convert_sdssrz_to_jhk"
                 elif {'SDSSgMag', 'SDSSiMag'}.issubset(subset):
                     method_name_test = "convert_sdssgi_to_jhk"
-                elif {'SDSSiMag', 'SDSSzMag'}.issubset(subset):
-                    method_name_test = "convert_sdssiz_to_jhk"
+                # elif {'SDSSiMag', 'SDSSzMag'}.issubset(subset):  # Add back in once GSSS uses this pair
+                #     method_name_test = "convert_sdssiz_to_jhk"
 
                 elif {'JpgMag', 'NpgMag'}.issubset(subset):
                     method_name_test = "convert_gsc2bjin_to_jhk"
@@ -91,9 +91,9 @@ def test_convert_mag_to_jhk():
 
 testdata = [
     (15, 15, 15, 25, 25, 25, 25, 'convert_tmass_to_jhk', 'convert_tmass_to_jhk', 'convert_tmass_to_jhk'),
-    (-999, -999, -999, 25, 15, 25, 15, 'convert_sdssiz_to_jhk', 'convert_sdssiz_to_jhk', 'convert_sdssiz_to_jhk'),
+    (-999, -999, -999, 15, 25, 25, 15, 'convert_sdssgi_to_jhk', 'convert_sdssgi_to_jhk', 'convert_sdssgi_to_jhk'),
 ]
-ids = ['tmass conversion with faint sdss', 'sdss-zi conversion because of faint g-band']
+ids = ['tmass conversion with faint sdss', 'sdss-gi conversion because of faint r an z bands']
 @pytest.mark.parametrize("jmag, hmag, kmag, gmag, zmag, rmag, imag, convert_j, convert_h, convert_k", testdata, ids=ids)
 def test_check_band_below_faint_limits_pass(jmag, hmag, kmag, gmag, zmag, rmag, imag, convert_j, convert_h, convert_k):
     """

--- a/fgscountrate/tests/test_convert_jhk.py
+++ b/fgscountrate/tests/test_convert_jhk.py
@@ -266,12 +266,12 @@ def test_sdssgz_to_jhk():
     # Check conversion function matches hand-check here
     assert np.isclose(j_ser, 11.191999999999998, 1e-5)
     assert np.isclose(h_ser, 11.041, 1e-5)
-    assert np.isclose(k_ser, 10.749, 1e-5)
+    assert np.isclose(k_ser, 10.74, 1e-5)
 
     # Check uncertainties
     assert np.isclose(j_err_ser, 0.27265120293170503, 1e-5)
     assert np.isclose(h_err_ser, 0.24635741034709235, 1e-5)
-    assert np.isclose(k_err_ser, 0.2439674603454265, 1e-5)
+    assert np.isclose(k_err_ser, 0.24035821994429607, 1e-5)
 
 
 def test_sdssgi_to_jhk():

--- a/fgscountrate/tests/test_convert_jhk.py
+++ b/fgscountrate/tests/test_convert_jhk.py
@@ -155,6 +155,31 @@ def test_check_band_below_faint_limits_failure():
     assert 'Cannot compute FGS countrate & magnitude for a guide star' in str(e_info.value)
 
 
+def test_bad_sdss_gz_limits():
+    """Test that when SDSSgMag and SDSSzMag color differences are bad, that conversion is skipped"""
+
+    gs_id = 'N13I000018'
+    guider = 1
+    fgs = FGSCountrate(guide_star_id=gs_id, guider=guider)
+
+    # Reset data to a set of constant, fake data with SDSS_g and z having bad color ranges and tmass missing
+    fgs.gsc_series = BASE_DATA
+    fgs.gsc_series['tmassJMag'] = -999
+    fgs.gsc_series['tmassHMag'] = -999
+    fgs.gsc_series['tmassKsMag'] = -999
+    fgs.gsc_series['SDSSgMag'] = 20
+    fgs.gsc_series['SDSSzMag'] = 14
+
+    # Convert to JHK magnitudes
+    fgs.j_mag, fgs.j_mag_err, fgs.h_mag, fgs.h_mag_err, fgs.k_mag, fgs.k_mag_err = \
+        fgs.calc_jhk_mag(fgs.gsc_series)
+
+    # Check that the conversion method is the next SDSS one that doesn't include SDSS_g-z
+    assert fgs.j_convert_method == 'convert_sdssrz_to_jhk'
+    assert fgs.h_convert_method == 'convert_sdssrz_to_jhk'
+    assert fgs.k_convert_method == 'convert_sdssrz_to_jhk'
+
+
 def test_tmass_to_jhk():
     """
     Check the _tmass_to_jhk method produces the expected result

--- a/fgscountrate/utils.py
+++ b/fgscountrate/utils.py
@@ -107,7 +107,12 @@ def query_gsc(gs_id=None, ra=None, dec=None, cone_radius=None, minra=None, maxra
     url = url + f'FORMAT={file_format}&CAT={catalog}'
 
     # Query data
-    request = requests.get(url).content
+    try:
+        request = requests.get(url).content
+    except requests.ConnectionError as e:
+        raise ConnectionError(f'Cannot connect to Guide Star Catalog. Catalog or internet may be down. '
+                              f'See full error below.\n {e}')
+
 
     # Read data into pandas
     try:

--- a/fgscountrate/utils.py
+++ b/fgscountrate/utils.py
@@ -101,22 +101,22 @@ def query_gsc(gs_id=None, ra=None, dec=None, cone_radius=None, minra=None, maxra
     # Set URL
     url = 'http://gsss.stsci.edu/webservices/vo/CatalogSearch.aspx?'
     if gs_id is not None:
-        url = url + 'GSC2ID={}&'.format(gs_id)
+        url = url + f'GSC2ID={gs_id}&'
     if ra is not None:
-        url = url + 'RA={}&'.format(ra)
+        url = url + f'RA={ra}&'
     if dec is not None:
-        url = url + 'DEC={}&'.format(dec)
+        url = url + f'DEC={dec}&'
     if cone_radius is not None:
-        url = url + 'SR={}&'.format(cone_radius)
+        url = url + f'SR={cone_radius}&'
     if minra is not None:
-        url = url + 'BBOX={}%2c'.format(minra)
+        url = url + f'BBOX={minra}%2c'
     if mindec is not None:
-        url = url + '{}%2c'.format(mindec)
+        url = url + f'{mindec}%2c'
     if maxra is not None:
-        url = url + '{}%2c'.format(maxra)
+        url = url + f'{maxra}%2c'
     if maxdec is not None:
-        url = url + '{}&'.format(maxdec)
-    url = url + 'FORMAT={}&CAT={}'.format(file_format, catalog)
+        url = url + f'{maxdec}&'
+    url = url + f'FORMAT={file_format}&CAT={catalog}'
 
     # Query data
     request = requests.get(url).content
@@ -126,7 +126,7 @@ def query_gsc(gs_id=None, ra=None, dec=None, cone_radius=None, minra=None, maxra
         data_frame = pd.read_csv(io.StringIO(request.decode('utf-8')), skiprows=1, na_values=[' '])
         data_frame.replace(np.nan, -999, regex=True, inplace=True)
     except pd.errors.EmptyDataError:
-        raise NameError("No guide stars match these requirements in catalog {}".format(catalog))
+        raise NameError(f"No guide stars match these requirements in catalog {catalog}")
 
     # Update header to new capitalization if using an old GSC version
     if catalog in ['GSC2412', 'GSC241']:

--- a/fgscountrate/utils.py
+++ b/fgscountrate/utils.py
@@ -183,7 +183,7 @@ def check_sdss_gz_limits(mags):
     g = mags[0]
     z = mags[1]
 
-    if g-z > 5 or g-z < -1:
+    if g-z > 5 or g-z < 0:
         return True
     else:
         return False

--- a/fgscountrate/utils.py
+++ b/fgscountrate/utils.py
@@ -138,24 +138,27 @@ def check_band_below_faint_limits(bands, mags):
 
     Returns
     -------
-    bool : True if the band if below the faint limit. False if it is not
+    list : a new list of bands that are above the faint limit (ie - use-able bands)
     """
     if isinstance(bands, str):
         bands = [bands]
     if isinstance(mags, float):
         mags = [mags]
 
+    new_bands = []
     for band, mag in zip(bands, mags):
         if 'SDSSgMag' in band and mag >= 24:
-            return True
+            continue
         elif 'SDSSrMag' in band and mag >= 24:
-            return True
+            continue
         elif 'SDSSiMag' in band and mag >= 23:
-            return True
+            continue
         elif 'SDSSzMag' in band and mag >= 22:
-            return True
+            continue
+        else:
+            new_bands.append(band)
 
-    return False
+    return new_bands
 
 
 def check_sdss_gz_limits(mags):

--- a/fgscountrate/utils.py
+++ b/fgscountrate/utils.py
@@ -4,6 +4,8 @@ import numpy as np
 import pandas as pd
 import requests
 
+from .constants import ABMAG_CONSTANTS
+
 
 def convert_to_abmag(value, name):
     """
@@ -21,21 +23,7 @@ def convert_to_abmag(value, name):
 
     """
 
-    mag_constants = {
-        'tmassJMag': 0.90,
-        'tmassHMag': 1.37,
-        'tmassKsMag': 1.85,
-        'SDSSuMag': 0.0,
-        'SDSSgMag': 0.0,
-        'SDSSrMag': 0.0,
-        'SDSSiMag': 0.0,
-        'SDSSzMag': 0.0,
-        'JpgMag': -0.055,
-        'FpgMag': 0.24,
-        'NpgMag': 0.48,
-    }
-
-    abmag = value + mag_constants[name]
+    abmag = value + ABMAG_CONSTANTS[name]
 
     return abmag
 

--- a/fgscountrate/utils.py
+++ b/fgscountrate/utils.py
@@ -158,6 +158,29 @@ def check_band_below_faint_limits(bands, mags):
     return False
 
 
+def check_sdss_gz_limits(mags):
+    """
+    Check if we can use the SDSSS G-Z conversion at the blue and
+    red end of the spectrum.
+
+    Parameters
+    ----------
+    mags : list
+        Magnitudes of the SDSS G and Z bands, in order
+
+    Returns
+    -------
+    bool : True if SDSS-GZ cannot be used. False if it can
+    """
+    g = mags[0]
+    z = mags[1]
+
+    if g-z > 5 or g-z < -1:
+        return True
+    else:
+        return False
+
+
 def trapezoid_sum(df, col, col2='Wavelength'):
     """
     Sum across a Pandas dataframe of values

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,12 +9,12 @@ license = Aura
 url = http://stsci.edu
 edit_on_github = False
 github_project = spacetelescope/jwst-fgs-countrate
-minimum_python_version = 3.5
+minimum_python_version = 3.6
 
 [options]
 packages = find:
 zip_safe = False
-python_requires = >=3.5
+python_requires = >=3.6
 include_package_data = True
 install_requires =
     pandas

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(name='fgscountrate',
         # 'License :: OSI Approved :: MIT License',
         'Intended Audience :: Science/Research',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: Scientific/Engineering :: Astronomy'
       ],


### PR DESCRIPTION
These are some changes to the code to better match the GSSS. See below for a full list.

Changes:
* Only include SDSS or GSC data in CR and magnitude calculations
    * Base it first on what was used to calculated JHK
    * Then base it on what data is present in the code
    * From Ed: “Breaking the calculations for GSC2.3 and SDSS makes sense (and is what GSS does). The optical bands of the two catalogs overlap one another, so using both would be double counting."
* J and K cannot be missing, but H can - raise an error in that case
    * If J,H, and K cannot be calculated, return -999 rather than raise an error
    * Add an error elsewhere only for J and K missing, not H
    * From Ed: “If tmass J or K is missing and there is not adequated SDSS of GSC bands available, skip the star."
* Remove error that J, H, and K alone can’t be used to calculate cr/mag (they can)
    * From Ed: “Yes, with 3 tmass bands we can still do calculation… With the tmass bands, the extended bands (3 to 5.5 microns) are still calculated in the usual way."
* Remove setting edge bands to 0 if missing - GSSS didn’t do that
* Move all constants to their own file
* Add color check for g-z only 
    * From Ed: "do not use the (g,z) transforms when g-z > 5 and g-z < 0."
* Add r-z conversion option after g-z to match Beverly’s code
* Update minimum version of code to python 3.6
* Remove dim stars from being used in any calculations (jhk and cr/mag)
* Add a more helpful error for when GSC is down
* Add more tests
* Add helpful error if a star has negative magnitude values

New:
* Remove SDSS I-Z conversion until GSS includes it in their code
    * From Ed: "My strong preference is to keep MAGIC synch’ed with GSS."
* Remove G-Z color difference check until GSS includes it in their code
    * From Ed: "My strong preference is to keep MAGIC synch’ed with GSS."
* Update SDSS vs GSC check. SDSS
    * From Beverly: SDSS is "only called if one of these SDSS bandpass pairs are available: g and z, r and z, or g and i." Otherwise, the code calls GSC2.