### PR TITLE
Update to be able to calculate magnitudes with GSC 2.3.4

### DIFF
--- a/fgscountrate/utils.py
+++ b/fgscountrate/utils.py
@@ -125,6 +125,21 @@ def query_gsc(gs_id=None, ra=None, dec=None, cone_radius=None, minra=None, maxra
     if catalog in ['GSC2412', 'GSC241']:
         data_frame = data_frame.rename(columns={'tmassJmag': 'tmassJMag', 'tmassJmagErr': 'tmassJMagErr',
                                                 'tmassHmag': 'tmassHMag', 'tmassHmagErr': 'tmassHMagErr'})
+    elif catalog in ['GSC23']:
+        data_frame = data_frame.rename(columns={'JMag': 'tmassJMag', 'JMagErr': 'tmassJMagErr',
+                                                'HMag': 'tmassHMag', 'HMagErr': 'tmassHMagErr',
+                                                'KMag': 'tmassKsMag', 'KMagErr': 'tmassKsMagErr',})
+
+    # For GSC 2.3 we don't have SDSS data so make sure this is clear in the data frame
+    if catalog in ['GSC23']:
+        check_list = ['SDSSuMag', 'SDSSgMag', 'SDSSrMag', 'SDSSiMag', 'SDSSzMag',
+                      'SDSSuMagErr', 'SDSSgMagErr', 'SDSSrMagErr', 'SDSSiMagErr', 'SDSSzMagErr']
+        for item in check_list:
+            try:
+                data_frame[item]
+            except KeyError:
+                data_frame[item] = -999
+
     return data_frame
 
 


### PR DESCRIPTION
We have discovered a mismatch between GSC 2.3.4 and GSC 2.4.2 in that some of the 2MASS magnitudes were overwritten by VISTA magnitudes in GSC 2.4.2. This is a problem for bright guide stars since VISTA is most sensitive to faint sources. 

As a result we need to be able to calculate FGS magnitudes based on GSC 2.3.4, which had very different column names. This PR matches the correct columns and deals with the missing SDSS bands which were not present in GSC 2.3.4  so that we can use 'GSC23' as a viable catalog for calculating the magnitudes. The way I tested this is as follows (the guide star used is the one that caused problems so we already know that there will be a difference in the magnitudes:

```
guide_star_id = 'S4OL071716'
guider_number = 1 

fgs = fgscountrate.FGSCountrate(guide_star_id=guide_star_id, guider=guider_number) 
count_rate, _, magnitude, _ = fgs.query_fgs_countrate_magnitude(catalog='GSC242')
```
vs 
```
guide_star_id = 'S4OL071716'
guider_number = 1 

fgs = fgscountrate.FGSCountrate(guide_star_id=guide_star_id, guider=guider_number) 
count_rate, _, magnitude, _ = fgs.query_fgs_countrate_magnitude(catalog='GSC23')
print(magnitude)
```
We are expecting a magnitude of 10.08 for GSC 2.4.2 and around 8.98 (this was the number calculated by Ed with a marginally different code) for GSC 2.3.4. When running the above, I get a magnitude of 8.96 using the numbers from 2.3.4.
